### PR TITLE
Mobile styling for about page

### DIFF
--- a/app/components/about-page/event.tsx
+++ b/app/components/about-page/event.tsx
@@ -10,10 +10,12 @@ const Event = ({ image, title, description }: EventProps) => {
       <img
         src={image ?? "app/icons/leaders.png"}
         alt={title ?? "Event Title"}
-        className="w-full border border-black object-cover shadow-default mb-4"
+        className="w-full border border-black object-cover shadow-mobile md:shadow md:mb-4"
       />
-      <p className="text-2xl text-indigo-600 pt-4">{title ?? "Event Title"}</p>
-      <p className="text-base text-gray-500 pt-3 pb-6">
+      <p className="text-[10px] md:text-2xl text-indigo-600 mt-3 md:mt-4">
+        {title ?? "Event Title"}
+      </p>
+      <p className="text-[8px] md:text-base mt-1.5 md:mt-3 mb-6">
         {description ?? "Event Description"}
       </p>
     </div>

--- a/app/components/about-page/events-carousel.tsx
+++ b/app/components/about-page/events-carousel.tsx
@@ -10,6 +10,8 @@ import { Button } from "../ui/button";
 import Event, { EventProps } from "./event";
 import { CarouselApi } from "../ui/carousel";
 
+type AlignmentOptionType = "center" | "start" | "end";
+
 interface EventsCarouselProps {
   events: EventProps[];
 }
@@ -18,6 +20,9 @@ const EventsCarousel = ({ events }: EventsCarouselProps) => {
   const [api, setApi] = useState<CarouselApi>();
   const [current, setCurrent] = useState(0);
   const count = events.length;
+  const [alignOption, setAlignOption] = useState(
+    "start" as AlignmentOptionType,
+  );
 
   useEffect(() => {
     if (!api) {
@@ -27,23 +32,33 @@ const EventsCarousel = ({ events }: EventsCarouselProps) => {
     api.on("select", () => {
       setCurrent(api.selectedScrollSnap());
     });
-
-    setCurrent(api.selectedScrollSnap());
   }, [api]);
+
+  useEffect(() => {
+    const updateAlignOption = () => {
+      setAlignOption(window.innerWidth < 768 ? "center" : "start");
+    };
+    updateAlignOption();
+    window.addEventListener("resize", updateAlignOption);
+    return () => window.removeEventListener("resize", updateAlignOption);
+  }, []);
 
   return (
     <div className="flex flex-col justify-center">
       <Carousel
         setApi={setApi}
         opts={{
-          align: "start",
+          align: alignOption,
           loop: true,
         }}
         className="w-full"
       >
         <CarouselContent className="-ml-2 md:-ml-4 mr-2">
           {events.map((event, index) => (
-            <CarouselItem key={index} className="basis-1/3 md:pl-4">
+            <CarouselItem
+              key={index}
+              className="basis-7/12 md:basis-1/3 md:pl-4"
+            >
               <Event
                 image={event.image}
                 title={event.title}
@@ -52,11 +67,12 @@ const EventsCarousel = ({ events }: EventsCarouselProps) => {
             </CarouselItem>
           ))}
         </CarouselContent>
-        <CarouselPrevious />
-        <CarouselNext />
+
+        <CarouselPrevious className="hidden md:flex" />
+        <CarouselNext className="hidden md:flex" />
       </Carousel>
-      <div className="py-2 text-center">
-        <div className="flex justify-center items-center gap-2 pt-2 pb-16">
+      <div className="md:py-2 text-center">
+        <div className="flex justify-center items-center gap-2 md:pt-2 pb-14 md:pb-16">
           {Array.from({ length: count }).map((_, index) => (
             <Button
               key={index}
@@ -64,8 +80,8 @@ const EventsCarousel = ({ events }: EventsCarouselProps) => {
               size="icon"
               className={`rounded-full ${
                 index === current
-                  ? "bg-indigo-600 w-4 h-4"
-                  : "bg-muted w-2.5 h-2.5"
+                  ? "bg-indigo-600 w-3 h-3 md:w-4 md:h-4 " + current + index
+                  : "bg-muted w-2 h-2 md:w-2.5 md:h-2.5 " + current + index
               }`}
               onClick={() => api?.scrollTo(index)}
             />

--- a/app/components/about-page/events-section.tsx
+++ b/app/components/about-page/events-section.tsx
@@ -24,18 +24,20 @@ export default function EventsSection({ cde, pde }: EventsSectionProps) {
 
   return (
     <div>
-      <h2 className="text-3xl py-16">Events</h2>
-      <h3 className="pb-16 text-2xl">
+      <h2 className="text-lg mt-12 mb-4 md:text-3xl md:my-16 font-medium">
+        Events
+      </h2>
+      <h3 className="text-xs mb-12 md:text-2xl md:mb-16 font-medium">
         Throughout the school year, C4C hosts a variety of professional
         development and community development events, both for its internal
         members and the greater Northeastern community. See below for some of
         our past mixers, workshops, and more!
       </h3>
-      <h2 className="text-3xl text-indigo-600 pb-10">
+      <h2 className="text-lg md:text-3xl text-indigo-600 mb-4 md:mb-10 font-medium">
         Community Development Events
       </h2>
       <EventsCarousel events={cdEvents} />
-      <h2 className="text-3xl text-indigo-600 pb-10">
+      <h2 className="text-lg md:text-3xl text-indigo-600 mb-4 md:mb-10 font-medium">
         Professional Development Events
       </h2>
       <EventsCarousel events={pdEvents} />

--- a/app/components/about-page/main-section.tsx
+++ b/app/components/about-page/main-section.tsx
@@ -1,21 +1,26 @@
 const MainSection = () => {
   return (
     <div>
-      <h1 className="text-5xl pb-16">
+      <h1 className="text-2xl mb-8 font-medium md:text-5xl md:mb-16">
         About <span className="text-indigo-600">Code4Community</span>
       </h1>
       <div className="flex justify-center">
         <div
           className="bg-[linear-gradient(to_right_bottom,rgba(243,235,249,0.75),rgba(243,235,249,0.75)),url('app/images/main.png')]
-                        bg-cover bg-no-repeat border border-black shadow-default text-4xl px-20 py-28"
+                        bg-cover bg-no-repeat border border-black shadow
+                        text-xs px-6 py-10
+                        md:text-4xl md:px-20 md:py-28
+                        font-medium"
         >
           Empowering through tech, fostering diversity, and leaving a lasting
           impact.
         </div>
       </div>
 
-      <h2 className="text-4xl pt-16">Our Culture</h2>
-      <h3 className="text-2xl py-16">
+      <h2 className="text-lg mt-10 font-medium md:text-4xl md:mt-16">
+        Our Culture
+      </h2>
+      <h3 className="text-xs my-6 md:text-2xl md:my-16 font-medium">
         At C4C, we embody a culture of purposeful innovation, where impactful,
         deliberate, and inclusive software development is not just a goal but a
         way of life. As Northeastern University’s sole student-led collective

--- a/app/components/about-page/numbers-section.tsx
+++ b/app/components/about-page/numbers-section.tsx
@@ -1,41 +1,67 @@
 const NumbersSection = () => {
   return (
-    <div className="mb-28">
-      <h2 className="text-3xl pb-16">By the Numbers</h2>
-      <div className="flex justify-center columns-3">
-        <div>
-          <h2 className="text-4xl pl-10 pb-9">
-            <span className="text-indigo-600 text-5xl">50+ </span>
+    <div className="mb-72 md:mb-28">
+      <h2 className="text-lg mb-4 md:text-3xl md:mb-16 font-medium">
+        By the Numbers
+      </h2>
+      <div className="flex justify-center md:columns-3 relative md:static">
+        <div className="z-10">
+          <h2
+            className="text-sm md:text-4xl font-medium
+                          md:ml-10 md:mb-9 md:static
+                          absolute left-[-5%]"
+          >
+            <span className="text-indigo-600 text-lg md:text-5xl">50+ </span>
             active members
           </h2>
-          <h2 className="text-4xl pl-16 pb-9">
-            <span className="text-indigo-600 text-5xl">5 </span>
-            websites deployed
+          <h2
+            className="text-sm md:text-4xl font-medium
+                        md:pl-16 md:pb-9 md:static
+                        absolute top-20 left-[-3%]"
+          >
+            <span className="text-indigo-600 text-lg md:text-5xl">100k </span>
+            users
           </h2>
-          <h2 className="text-4xl pb-9">
-            <span className="text-indigo-600 text-5xl">10 </span>
+          <h2
+            className="text-sm md:text-4xl font-medium
+                        md:pb-9 md:static
+                        absolute top-52 left-0"
+          >
+            <span className="text-indigo-600 text-lg md:text-5xl">10 </span>
             nonprofit partners
           </h2>
         </div>
-        <div className="flex justify-center">
+        <div className="flex justify-center absolute md:static z-0">
           <img
             src="app/images/numbers.png"
             alt="Illustration"
-            className="w-80 h-auto"
+            className="w-52 md:w-80 h-auto"
           />
         </div>
-        <div className="text-right">
-          <h2 className="text-4xl pr-14 pb-9">
-            <span className="text-indigo-600 text-5xl">10k </span>
+        <div className="md:text-right">
+          <h2
+            className="text-sm md:text-4xl font-medium
+                        md:mr-14 md:mb-9 md:static
+                        absolute top-[-10%] left-[60%]"
+          >
+            <span className="text-indigo-600 text-lg md:text-5xl">10k </span>
             lines of code
           </h2>
-          <h2 className="text-4xl pr-28 pb-9">
-            <span className="text-indigo-600 text-5xl">500 </span>
+          <h2
+            className="text-sm md:text-4xl font-medium
+                        md:mr-28 md:mb-9 md:static
+                        absolute top-16 left-[80%]"
+          >
+            <span className="text-indigo-600 text-lg md:text-5xl">500 </span>
             pull requests
           </h2>
-          <h2 className="text-4xl pb-9">
-            <span className="text-indigo-600 text-5xl">100k </span>
-            users
+          <h2
+            className="text-sm md:text-4xl font-medium
+                        md:mb-9 md:static
+                        absolute top-48 left-2/3"
+          >
+            <span className="text-indigo-600 text-lg md:text-5xl">5 </span>
+            websites deployed
           </h2>
         </div>
       </div>

--- a/app/components/about-page/we-are-component.tsx
+++ b/app/components/about-page/we-are-component.tsx
@@ -1,21 +1,31 @@
-export interface AboutProps {
+export interface WeAreProps {
   image?: string;
   title?: string;
   description?: string;
 }
 
-const WeAreComponent = ({ image, title, description }: AboutProps) => {
+const WeAreComponent = ({ image, title, description }: WeAreProps) => {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-row md:flex-col items-start">
       <img
         src={image ?? "app/icons/community.png"}
         alt={title ?? "About component image"}
-        className="w-full border border-black object-cover shadow-default mb-4"
+        className="w-36 mb-0 shadow-mobile 
+                  md:w-full md:mb-4 md:shadow 
+                  h-auto border border-black object-contain"
       />
-      <p className="text-2xl text-indigo-600 pt-9 pb-3"> {title ?? "Title"}</p>
-      <p className="py-4 text-base text-gray-500">
-        {description ?? "Lorem ipsum."}
-      </p>
+      <div className="ml-4 md:ml-0">
+        <p
+          className="text-[10px] md:text-2xl font-medium text-indigo-600 
+                      mb-2 md:mt-9 md:mb-3"
+        >
+          {" "}
+          {title ?? "Title"}
+        </p>
+        <p className="text-[8px] md:text-base md:py-4 text-gray">
+          {description ?? "Lorem ipsum."}
+        </p>
+      </div>
     </div>
   );
 };

--- a/app/components/about-page/we-are-section.tsx
+++ b/app/components/about-page/we-are-section.tsx
@@ -1,17 +1,19 @@
-import AboutComponent, { AboutProps } from "./we-are-component";
+import WeAreComponent, { WeAreProps } from "./we-are-component";
 
-interface WeAreProps {
-  aboutItems: AboutProps[];
+interface Props {
+  aboutItems: WeAreProps[];
 }
 
-const WeAreSection = ({ aboutItems }: WeAreProps) => {
+const WeAreSection = ({ aboutItems }: Props) => {
   return (
     <div>
-      <h2 className="text-4xl pb-12 text-indigo-600">We are</h2>
+      <h2 className="text-lg mb-2 md:text-4xl md:mb-12 text-indigo-600 font-medium">
+        We are
+      </h2>
       <div className="flex flex-col items-center text-indigo-600">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
           {aboutItems.map((item, index) => (
-            <AboutComponent
+            <WeAreComponent
               key={index}
               image={item.image}
               title={item.title}

--- a/app/components/icons/RightQuote.tsx
+++ b/app/components/icons/RightQuote.tsx
@@ -1,16 +1,3 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
->
-  <path
-    d="M14 7L16 11H13V17H19V11L17 7H14ZM6 7L8 11H5V17H11V11L9 7H6Z"
-    fill="#B772EA"
-  />
-</svg>;
-
 import type { SVGProps } from "react";
 const SvgRQuote = (props: SVGProps<SVGSVGElement>) => (
   <svg

--- a/app/components/ui/carousel.tsx
+++ b/app/components/ui/carousel.tsx
@@ -205,7 +205,7 @@ const CarouselPrevious = React.forwardRef<
       variant={variant}
       size={size}
       className={cn(
-        "absolute  h-8 w-8 rounded-full",
+        "absolute h-8 w-8 rounded-full",
         orientation === "horizontal"
           ? "-left-12 top-1/2 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,7 +19,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body>
+      <body className="text-gray">
         <Navbar />
         {children}
         <Footer />

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -52,7 +52,7 @@ export default function About() {
 
   return (
     <div>
-      <div className="px-40 pt-20 gap-18">
+      <div className="px-8 pt-12 gap-12 md:px-40 md:pt-20 md:gap-18">
         <MainSection />
         <WeAreSection aboutItems={aboutItems} />
         <EventsSection cde={cde} pde={pde} />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,12 +11,14 @@ export default {
         sm: "calc(var(--radius) - 4px)",
       },
       boxShadow: {
-        default: "8px 8px 0px 0px #4A4A51",
-        mini: "4px 4px 0px 0px #4A4A51",
+        DEFAULT: "8px 8px #4A4A51",
+        small: "4px 4px #4A4A51",
+        mobile: "1.5px 1.5px #4A4A51",
       },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        gray: "#333333",
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",


### PR DESCRIPTION
### ℹ️ Issue

### 📝 Description

Briefly list the changes made to the code:

1. Added mobile-sized shadow
2. Added styling for mobile
3. Set main font color for website to be custom gray

### ✔️ Verification

Viewed on dev server.

https://github.com/user-attachments/assets/1d312f50-4466-4849-823f-b965b57ebd71

### 🏕️ (Optional) Future Work / Notes

Coloring of events carousel selected button isn't responsive on Chrome for me, but works fine on Firefox. 
Currently updating navbar to work on mobile. 
"By the Numbers" section was the best I could do, don't know if we can change to make it better.
