### PR TITLE
Fixed nav bar spacing on mobile

### DIFF
--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -37,7 +37,7 @@ export default function About() {
 
   return (
     <div className="flex justify-center">
-      <div className="w-[90%] md:max-w-[1100px]">
+      <div className="mt-24 md:mt-0 w-[90%] md:max-w-[1100px]">
         <MainSection
           tagline={asText(aboutData.about_pic_text)}
           culture_description={asText(aboutData.culture_description)}

--- a/app/routes/apply.$position.tsx
+++ b/app/routes/apply.$position.tsx
@@ -32,12 +32,10 @@ export default function Role() {
 
   return (
     <div className="flex justify-center">
-      <div className="md-12 w-[90%] md:max-w-[1100px]">
+      <div className="mt-24 md:mt-12 w-[90%] md:max-w-[1100px]">
         <RoleDetailsCard
           image1={asImageSrc(position?.top_pic) ?? undefined}
-          //image1Alt={"missing"}
           image2={asImageSrc(position?.bottom_pic) ?? undefined}
-          //image2Alt={"idk"}
           title={asText(position?.name) ?? ""}
           tagline={asText(position?.tag_line) ?? ""}
           roleParagraph={

--- a/app/routes/apply._index.tsx
+++ b/app/routes/apply._index.tsx
@@ -64,7 +64,7 @@ export default function Apply() {
 
   return (
     <div className="flex justify-center">
-      <div className="w-[90%] md:max-w-[1100px]">
+      <div className="mt-24 md:mt-0 w-[90%] md:max-w-[1100px]">
         <JoinTeamSection
           description={asText(applyPage.join_team_description) ?? ""}
         />

--- a/app/routes/faqs.tsx
+++ b/app/routes/faqs.tsx
@@ -28,7 +28,7 @@ export default function FAQs() {
 
   return (
     <div className="flex justify-center">
-      <div className="w-[90%] md:max-w-[1100px]">
+      <div className="mt-24 md:mt-0 w-[90%] md:max-w-[1100px]">
         <h1 className="mb-9 md:mt-[120px] md:mb-[72px] text-2xl md:text-5xl font-medium shrink-0">
           Frequently Asked <span className="text-indigo-600">Questions</span>
         </h1>

--- a/app/routes/partners.tsx
+++ b/app/routes/partners.tsx
@@ -64,7 +64,7 @@ export default function Clients() {
 
   return (
     <div className="flex justify-center">
-      <div className="w-[90%] md:max-w-[1100px]">
+      <div className="mt-24 md:mt-0 w-[90%] md:max-w-[1100px]">
         <PartnerHeader {...clientQuote} />
         <h3 className="text-xl md:text-4xl mb-5 md:mb-8 font-medium">
           Current Partner Organizations

--- a/app/routes/people.tsx
+++ b/app/routes/people.tsx
@@ -150,7 +150,7 @@ export default function People() {
 
   return (
     <div className="flex justify-center">
-      <div className="w-[90%] md:max-w-[1100px]">
+      <div className="mt-24 md:mt-0 w-[90%] md:max-w-[1100px]">
         <h1 className="mb-9 md:mt-[120px] md:mb-[72px] text-4xl md:text-5xl font-medium shrink-0 text-left">
           Meet the <br className="block md:hidden" />
           <span className="text-indigo-600">

--- a/app/routes/projects._index.tsx
+++ b/app/routes/projects._index.tsx
@@ -34,7 +34,7 @@ export default function Projects() {
 
   return (
     <div className="flex justify-center overflow-hidden relative">
-      <div className="mt-24 w-[90%] md:max-w-[1100px] h-[45vh] flex justify-center items-center">
+      <div className="mt-24 md:mt-0 w-[90%] md:max-w-[1100px] h-[45vh] flex justify-center items-center">
         <h1 className="items-center  text-2xl md:text-5xl font-light">
           {" "}
           Coming soon ^_^


### PR DESCRIPTION
### ℹ️ Issue

Closes #99 

### 📝 Description

Previously, the navigation bar on mobile covered content. I added additional margins on mobile, and ensured that those margins are not added on medium and large screens to ensure no spacing issues occur on those devices. 

Briefly list the changes made to the code:

1. Added mt-24 on mobile to the top of all routes
3. Added mt-0 to medium and large screens to make sure there are no spacing issues

### ✔️ Verification

Visual verification (repeated on all pages) to make sure the spacing stayed the same on laptop:

![Uploading Screenshot 2025-06-04 at 12.05.18 AM.png…]()

Visual verification (repeated on all pages, using inspect element) to make sure the nav bar is properly spaced on mobile:

<img width="610" alt="Screenshot 2025-06-04 at 12 06 28 AM" src="https://github.com/user-attachments/assets/b8df8077-1a0d-4014-a5d2-0df2e27020b0" />


### 🏕️ (Optional) Future Work / Notes

n/a